### PR TITLE
feat(infra): inital config for deployment

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/heroku/heroku-buildpack-python.git

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: python manage.py migrate --noinput && python manage.py collectstatic --no-input
+web: gunicorn runtimeexceptions.wsgi

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,67 @@
+# Created by https://www.toptal.com/developers/gitignore/api/terraform,visualstudiocode,direnv
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform,visualstudiocode,direnv
+
+### direnv ###
+.direnv
+.envrc
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform,visualstudiocode,direnv
+
+*.lock.hcl
+
+imports.tf

--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -1,0 +1,66 @@
+.PHONY: help check init clean download upload all test
+.DEFAULT_GOAL: help
+.PRECIOUS: imports.tf terraform.tfvars
+
+CMD=$(shell which tofu || which terraform)
+ECHO=$(shell which figlet || which echo)
+
+.gitignore:
+	curl https://www.toptal.com/developers/gitignore/api/terraform,visualstudiocode,direnv > $@
+
+.git: .gitignore
+	git init
+
+init: check .terraform ## Fetch files from S3 and init
+
+download: clean imports.tf terraform.tfvars ## Refetch the imports and vars
+
+help: ## Display this help
+	@$(ECHO) Infrastructure
+	@echo Options:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@cat README.md
+
+.terraform: imports.tf terraform.tfvars
+	$(CMD) init \
+		-backend-config="key=${TERAFORM_BUCKET_PATH}/state.tfstate" \
+		-backend-config="bucket=${TERAFORM_BUCKET}" \
+		-backend-config="region=${TERAFORM_BUCKET_REGION}"
+	@touch $@
+
+imports.tf:
+	@aws s3 cp s3://${TERAFORM_BUCKET}/${TERAFORM_BUCKET_PATH}/$@ . || touch $@
+
+terraform.tfvars:
+	@aws s3 cp s3://${TERAFORM_BUCKET}/${TERAFORM_BUCKET_PATH}/$@ . || touch $@
+
+upload: imports.tf terraform.tfvars ## Upload the imports and vars to S3
+	@for f in $^; do aws s3 cp $$f s3://${TERAFORM_BUCKET}/${TERAFORM_BUCKET_PATH}/$$f; done
+
+check: ## Check the env vars are set
+ifndef TERAFORM_BUCKET
+	$(error "TERAFORM_BUCKET is required!")
+endif
+ifndef TERAFORM_BUCKET_REGION
+	$(error "TERAFORM_BUCKET_REGION is required!")
+endif
+ifndef TERAFORM_BUCKET_PATH
+	$(error "TERAFORM_BUCKET_PATH is required!")
+endif
+
+clean: ## Remove fetched files
+	@rm -f imports.tf terraform.tfvars
+
+apply: check .terraform ## Apply the terraform
+	$(CMD) apply
+
+destroy: check .terraform ## Destroy the terraform
+	$(CMD) destroy
+
+plan: check .terraform ## Plan the terraform
+	$(CMD) plan
+
+git-remote: ## Add the git remote
+	@git remote remove dokku
+	git remote add dokku $(shell tofu output -raw git-remote)

--- a/infrastructure/aws.tf
+++ b/infrastructure/aws.tf
@@ -1,0 +1,28 @@
+resource "aws_sesv2_email_identity" "email" {
+  email_identity = var.domain
+}
+
+resource "aws_iam_user" "primary" {
+  name = "${replace(var.domain, ".", "-")}-primary"
+}
+
+resource "aws_iam_access_key" "access_key" {
+  user = aws_iam_user.primary.name
+}
+
+data "aws_iam_policy_document" "ses_policy_document" {
+  statement {
+    actions   = ["ses:SendEmail", "ses:SendRawEmail"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ses_policy" {
+  name   = "${replace(var.domain, ".", "-")}-SES"
+  policy = data.aws_iam_policy_document.ses_policy_document.json
+}
+
+resource "aws_iam_user_policy_attachment" "user_policy" {
+  user       = aws_iam_user.primary.name
+  policy_arn = aws_iam_policy.ses_policy.arn
+}

--- a/infrastructure/cloudflare.tf
+++ b/infrastructure/cloudflare.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_record" "cname_dkim" {
+  count = 3
+
+  zone_id         = var.zoneid
+  name            = "${aws_sesv2_email_identity.email.dkim_signing_attributes[0].tokens[count.index]}._domainkey.${var.domain}"
+  content         = "${aws_sesv2_email_identity.email.dkim_signing_attributes[0].tokens[count.index]}.dkim.amazonses.com"
+  type            = "CNAME"
+  proxied         = false
+  comment         = "DKIM ${count.index} - SES"
+  depends_on      = [aws_sesv2_email_identity.email]
+  allow_overwrite = true
+}
+
+resource "cloudflare_record" "api" {
+  name            = "api"
+  proxied         = true
+  type            = "CNAME"
+  content         = var.hosting_domain
+  zone_id         = var.zoneid
+  allow_overwrite = true
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.23.1"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+    dokku = {
+      source  = "aliksend/dokku"
+      version = "~> 1.0.24"
+    }
+  }
+
+  backend "s3" {
+    encrypt = true
+  }
+}
+
+variable "domain" {
+  description = "Domain (no www)"
+}
+
+variable "email" {
+  description = "Email address"
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+}
+
+variable "hosting_domain" {
+  description = "Hosting domain"
+}
+
+variable "hosting_user" {
+  description = "SSH user for hosting"
+}
+
+variable "secret_key" {
+  description = "Django secret key"
+}
+
+variable "zoneid" {
+  description = "Cloudflare zone ID"
+}
+
+variable "git_repository" {
+  description = "Git repository for deployment"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "dokku" {
+  ssh_host = var.hosting_domain
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/infrastructure/runtimeexceptions.tf
+++ b/infrastructure/runtimeexceptions.tf
@@ -1,0 +1,98 @@
+resource "dokku_app" "runtimeexceptions" {
+  app_name = "runtimeexceptions"
+
+  domains = ["www.${var.domain}"]
+
+  config = {
+    DJANGO_SETTINGS_MODULE = "runtimeexceptions.settings.prod"
+    ALLOWED_HOSTS          = "www.${var.domain}"
+    BASE_URL               = "https://www.${var.domain}"
+    AWS_ACCESS_KEY_ID      = "${var.aws_access_key_id}"
+    AWS_SECRET_ACCESS_KEY  = "${var.aws_secret_access_key}"
+
+    SMTP_PASS = aws_iam_access_key.access_key.ses_smtp_password_v4
+    SMTP_USER = aws_iam_access_key.access_key.id
+    SMTP_PORT = "587"
+    SMTP_HOST = "email-smtp.${var.aws_region}.amazonaws.com"
+
+    STRAVA_CLIENT_ID = var.strava_client_id
+    STRAVA_SECRET = var.strava_secret
+    STRAVA_KEY = var.strava_key
+    OWM_API_KEY = var.owm_api_key
+
+    SECRET_KEY = var.secret_key
+  }
+
+  ports = {
+    80 = {
+      scheme         = "http"
+      container_port = 8000
+    }
+  }
+
+  deploy = {
+    type = "git_repository"
+    git_repository = var.git_repository
+  }
+}
+
+resource "dokku_plugin" "postgres" {
+  name = "postgres"
+  url  = "https://github.com/dokku/dokku-postgres.git"
+}
+
+resource "dokku_postgres" "main_db" {
+  service_name = "runtimeexceptions"
+  image = "postgres:17.5"
+
+  depends_on = [
+    dokku_plugin.postgres
+  ]
+}
+
+resource "dokku_postgres_link" "runtimeexceptions_db_link" {
+  app_name     = dokku_app.runtimeexceptions.app_name
+  service_name = dokku_postgres.main_db.service_name
+  alias        = "DATABASE"
+
+  depends_on = [
+    dokku_plugin.postgres
+  ]
+}
+
+output "git-remote" {
+  value       = "dokku@${var.hosting_domain}:${dokku_app.runtimeexceptions.app_name}"
+  description = "Git remote"
+  depends_on  = []
+}
+
+resource "dokku_plugin" "letsencrypt" {
+  name = "letsencrypt"
+  url  = "https://github.com/dokku/dokku-letsencrypt.git"
+}
+
+resource "dokku_letsencrypt" "runtimeexceptions" {
+  app_name = "runtimeexceptions"
+  email    = var.email
+
+  depends_on = [
+    dokku_app.runtimeexceptions,
+    dokku_plugin.letsencrypt
+  ]
+}
+
+variable "strava_client_id" {
+  description = "Strava Client ID"
+}
+
+variable "strava_secret" {
+  description = "Strava Secret"
+}
+
+variable "strava_key" {
+  description = "Strava Key"
+}
+
+variable "owm_api_key" {
+  description = "OWM API Key"
+}


### PR DESCRIPTION
## Summary by Sourcery

Provide initial Terraform-based infrastructure setup for deploying the Django application on Dokku with database, DNS, and SSL integration.

New Features:
- Introduce Terraform configuration for Dokku app deployment with Git repository and environment variables.
- Provision and link a PostgreSQL service via the Dokku Postgres plugin.
- Configure Let's Encrypt plugin for automatic TLS certificate management.
- Define AWS SES identity, IAM user, and email sending policy for the domain.
- Create Cloudflare DNS records for DKIM tokens and API subdomain routing.
- Define input variables for domain, hosting, AWS, Cloudflare, Strava, and OWM credentials.

Enhancements:
- Add Terraform providers (AWS, Cloudflare, Dokku) and S3 backend setup.
- Add Makefile with tasks for Terraform initialization, planning, applying, state management, and remote configuration.
- Include Procfile for Django release migrations, static asset collection, and Gunicorn web process.