### PR TITLE
infra

### DIFF
--- a/infrastructure/runtimeexceptions.tf
+++ b/infrastructure/runtimeexceptions.tf
@@ -7,8 +7,8 @@ resource "dokku_app" "runtimeexceptions" {
     DJANGO_SETTINGS_MODULE = "runtimeexceptions.settings.prod"
     ALLOWED_HOSTS          = "www.${var.domain}"
     BASE_URL               = "https://www.${var.domain}"
-    AWS_ACCESS_KEY_ID      = "${var.aws_access_key_id}"
-    AWS_SECRET_ACCESS_KEY  = "${var.aws_secret_access_key}"
+    AWS_ACCESS_KEY_ID      = aws_iam_access_key.access_key.id
+    AWS_SECRET_ACCESS_KEY  = aws_iam_access_key.access_key.secret
 
     SMTP_PASS = aws_iam_access_key.access_key.ses_smtp_password_v4
     SMTP_USER = aws_iam_access_key.access_key.id

--- a/runtimeexceptions/settings/base.py
+++ b/runtimeexceptions/settings/base.py
@@ -100,3 +100,5 @@ STRAVA_KEY = os.environ.get("STRAVA_KEY")
 OWM_API_KEY = os.environ.get("OWM_API_KEY")
 
 DOMAIN = os.environ.get("DOMAIN", "localhost:8000")
+
+STATIC_ROOT = os.path.join(BASE_DIR, "static")

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- **feat: configure static files**


- **fix: update AWS credentials to use IAM access key references**

## Summary by Sourcery

Configure static file handling and switch AWS credentials in Terraform to use IAM access key resources

New Features:
- Add STATIC_ROOT setting and static/.gitignore to manage collected static files

Bug Fixes:
- Update Terraform AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to reference aws_iam_access_key resource instead of variables