### PR TITLE
fix: update known_hosts entry to use secret variable for SSH_HOST_URL

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,9 +13,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fix known_hosts for git.flaminghedgehog.com
+      - name: Fix known_hosts 
         run: |
-          ssh-keygen -R git.flaminghedgehog.com || true
+          ssh-keygen -R ${{ secrets.SSH_HOST_URL }} || true
 
       - name: Push to dokku
         uses: dokku/github-action@master


### PR DESCRIPTION
## Summary by Sourcery

Switch the GitHub Actions deploy workflow to use the SSH_HOST_URL secret for the known_hosts entry instead of a hardcoded host

Enhancements:
- Replace hardcoded git.flaminghedgehog.com in ssh-keygen with the SSH_HOST_URL secret
- Update the deploy workflow step name for fixing known_hosts to remove the hardcoded hostname