### PR TITLE
feat: update event_time column to use timestamp with time zone in strava_update table

### DIFF
--- a/strava/migrations/0015_alter_update_event_time_alter_update_owner_id.py
+++ b/strava/migrations/0015_alter_update_event_time_alter_update_owner_id.py
@@ -11,6 +11,18 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE strava_update 
+                ALTER COLUMN event_time TYPE timestamp with time zone 
+                USING to_timestamp(event_time) AT TIME ZONE 'UTC';
+            """,
+            reverse_sql="""
+                ALTER TABLE strava_update 
+                ALTER COLUMN event_time TYPE integer 
+                USING EXTRACT(EPOCH FROM event_time)::integer;
+            """
+        ),
         migrations.AlterField(
             model_name='update',
             name='event_time',


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Convert strava_update.event_time column from integer epoch to timestamp with time zone and update the reverse migration to revert back to integer