### PR TITLE
feat: add CI workflow and update deploy workflow to trigger on CI completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: runtimeexceptions.settings.test
+      PYTHONUNBUFFERED: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements.test.txt
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,11 +1,15 @@
 ---
 name: "deploy"
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 jobs:
   deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-24.04
     steps:
       - name: Cloning repo


### PR DESCRIPTION
## Summary by Sourcery

Add a CI workflow for running tests on all pushes and pull requests and update the deploy workflow to trigger only after a successful CI run on the main branch

CI:
- Add CI workflow to install dependencies and run pytest on push and pull_request events

Deployment:
- Update deploy workflow to trigger on successful CI completion for the main branch