### PR TITLE
tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 release: python manage.py migrate --noinput && python manage.py collectstatic --no-input
 web: gunicorn runtimeexceptions.wsgi
+worker: python manage.py db_worker --settings=runtimeexceptions.settings.production --noreload

--- a/manage.py
+++ b/manage.py
@@ -17,6 +17,7 @@ def main():
     if (
         os.getenv("NGROK_LISTENER_RUNNING") is None
         and os.getenv("NGROK_AUTHTOKEN") is not None
+        and len(sys.argv) > 1
         and sys.argv[1] == "runserver"
     ):
         os.environ["NGROK_LISTENER_RUNNING"] = "true"

--- a/manage.py
+++ b/manage.py
@@ -14,7 +14,11 @@ def exit_handler():
 
 
 def main():
-    if os.getenv("NGROK_LISTENER_RUNNING") is None and os.getenv("NGROK_AUTHTOKEN") is not None:
+    if (
+        os.getenv("NGROK_LISTENER_RUNNING") is None
+        and os.getenv("NGROK_AUTHTOKEN") is not None
+        and sys.argv[1] == "runserver"
+    ):
         os.environ["NGROK_LISTENER_RUNNING"] = "true"
         import asyncio, ngrok  # noqa: E401, I001
 

--- a/runtimeexceptions/settings/base.py
+++ b/runtimeexceptions/settings/base.py
@@ -12,6 +12,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_tasks",
+    "django_tasks.backends.database",
     "template_tags",
     "strava",
     "weather",
@@ -90,7 +91,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 TASKS = {
     "default": {
-        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+        "BACKEND": "django_tasks.backends.database.DatabaseBackend",
     },
 }
 


### PR DESCRIPTION
- **fix: ensure ngrok listener only starts when running the server**


- **feat: setup the db task worker**

## Summary by Sourcery

Conditionally start the ngrok listener only when running the development server and configure a database-backed task worker.

New Features:
- Add a database-backed task worker process for background tasks

Bug Fixes:
- Prevent ngrok listener from starting unless invoking the runserver command

Enhancements:
- Register the database task backend in INSTALLED_APPS and switch the default tasks backend to DatabaseBackend

Deployment:
- Add a db_worker process entry to the Procfile for production deployment