### PR TITLE
docs(css): correct css build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ terraform apply
 
 CSS is built using PostCSS. Source files are in `css/`, output is in `static/css/`.
 ```bash
-npm run build:css
+make css
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace npm run build:css command with make css in README