### PR TITLE
fix: correct aspect type matching

### DIFF
--- a/strava/models.py
+++ b/strava/models.py
@@ -270,14 +270,14 @@ class Activity(models.Model):
 
 class Event(models.Model):
     ASPECT_TYPES: ClassVar[dict[str, str]] = {
-        "create": "Create",
-        "update": "Update",
-        "delete": "Delete",
+        "create": "create",
+        "update": "update",
+        "delete": "delete",
     }
 
     OBJECT_TYPES: ClassVar[dict[str, str]] = {
-        "activity": "Activity",
-        "athlete": "Athlete",
+        "activity": "activity",
+        "athlete": "athlete",
     }
 
     aspect_type = models.CharField(max_length=128, choices=ASPECT_TYPES)

--- a/strava/tasks/weather.py
+++ b/strava/tasks/weather.py
@@ -19,7 +19,7 @@ def set_weather(update_id: int):
     event = Event.objects.get(id=update_id)
     logger.info("Setting weather for event: %d with aspect_type: %s", event.pk, getattr(event, "aspect_type", None))
     if getattr(event, "aspect_type", None) != Event.ASPECT_TYPES["create"]:
-        logger.info("Event is not a create event, skipping weather update")
+        logger.info(f"Event is not a {Event.ASPECT_TYPES['create']} event, skipping weather update")
         return
 
     activity = Activity.find_or_create(event.owner_id, event.object_id)


### PR DESCRIPTION
## Summary by Sourcery

Standardize ASPECT_TYPES and OBJECT_TYPES choice values to lowercase and update the weather task log message to align with the new aspect_type values

Bug Fixes:
- Correct aspect_type and object_type mappings to use lowercase strings for consistent matching
- Update weather task log message to reference the lowercase 'create' aspect type when skipping updates