### PR TITLE
fix(strava): ensure dict is sent to make call

### DIFF
--- a/strava/models.py
+++ b/strava/models.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Iterable
 from http import HTTPStatus
 from math import atan2, cos, radians, sin, sqrt
-from typing import Any, ClassVar, Literal, TypeVar, cast
+from typing import Any, ClassVar, Literal, Self, TypeVar, cast
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -178,11 +178,12 @@ class Runner(models.Model):
         except ValidationError as e:
             raise Http404("Strava activity not found or invalid data") from e
 
-    def update_activity(self, activity_id, data) -> DetailedActivity:
+    def update_activity(self: Self, activity_id: int, data: DetailedActivity) -> DetailedActivity:
         """
         Updates an activity with the given data.
         """
-        result = self.make_call(f"activities/{activity_id}", data, method="PUT")
+
+        result = self.make_call(f"activities/{activity_id}", data.model_dump(), method="PUT")
         return DetailedActivity.model_validate(result)
 
     @staticmethod

--- a/strava/tests/models/test_runner.py
+++ b/strava/tests/models/test_runner.py
@@ -287,13 +287,13 @@ def test_activity_invalid(mock_strava_request):
 @patch("strava.models.Runner.make_call")
 def test_update_activity(mock_make_call):
     id = 1
-    data = {"name": "New Activity"}
+    data = DetailedActivity(name="New Activity")
     mock_make_call.return_value = data
     runner: Runner = baker.make(Runner, access_expires="9999999999")
     runner.update_activity(id, data)
     mock_make_call.assert_called_once_with(
         f"activities/{id}",
-        data,
+        data.model_dump(),
         method="PUT",
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Fix update_activity to serialize DetailedActivity data before making the API call

Bug Fixes:
- Ensure update_activity sends a dict (via model_dump) to make_call instead of passing the model object

Enhancements:
- Add explicit type hints for self, activity_id, and data in update_activity signature