### PR TITLE
triathlon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,3 +74,9 @@ repos:
   rev: v0.28.0
   hooks:
   - id: tach
+- repo: local
+  hooks:
+  - id: ty
+    name: ty check
+    entry: uvx ty check . --ignore unresolved-import
+    language: python

--- a/strava/mixins/__init__.py
+++ b/strava/mixins/__init__.py
@@ -1,3 +1,4 @@
+from strava.mixins.cleaning import CleanEmptyLatLngMixin
 from strava.mixins.triathlon import TriathlonMixin
 
-__all__ = ["TriathlonMixin"]
+__all__ = ["CleanEmptyLatLngMixin", "TriathlonMixin"]

--- a/strava/mixins/__init__.py
+++ b/strava/mixins/__init__.py
@@ -1,0 +1,3 @@
+from strava.mixins.triathlon import TriathlonMixin
+
+__all__ = ["TriathlonMixin"]

--- a/strava/mixins/cleaning.py
+++ b/strava/mixins/cleaning.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from pydantic import model_validator
+
+
+class CleanEmptyLatLngMixin:
+    @model_validator(mode="before")
+    @classmethod
+    def clean_empty_latlng(cls, data: Any) -> Any:
+        fixable_fields: list[str] = ["start_latlng", "end_latlng"]
+        for field in fixable_fields:
+            if isinstance(data.get(field), list) and not data[field]:
+                data[field] = None
+
+        return data

--- a/strava/mixins/cleaning.py
+++ b/strava/mixins/cleaning.py
@@ -8,8 +8,9 @@ class CleanEmptyLatLngMixin:
     @classmethod
     def clean_empty_latlng(cls, data: Any) -> Any:
         fixable_fields: list[str] = ["start_latlng", "end_latlng"]
+        _data = dict(data)
         for field in fixable_fields:
-            if isinstance(data.get(field), list) and not data[field]:
-                data[field] = None
+            if isinstance(_data.get(field), list) and not _data[field]:
+                _data[field] = None
 
-        return data
+        return _data

--- a/strava/mixins/triathlon.py
+++ b/strava/mixins/triathlon.py
@@ -1,5 +1,3 @@
-from typing import Protocol
-
 from strava.data_models import ActivityType
 
 SWIM_DISTANCE: int = 1500
@@ -13,12 +11,7 @@ TRIATHLON_DISTANCES = {
 }
 
 
-class Activity(Protocol):
-    distance: float | None
-    type: ActivityType | None
-
-
-class TriathlonMixin(Activity):
+class TriathlonMixin:
     def triathlon_percentage(self, precision: int = 2) -> float:
         try:
             return round(((self.distance or 0) / TRIATHLON_DISTANCES[self.type]) * 100, precision)

--- a/strava/mixins/triathlon.py
+++ b/strava/mixins/triathlon.py
@@ -1,0 +1,26 @@
+from typing import Protocol
+
+from strava.data_models import ActivityType
+
+SWIM_DISTANCE: int = 1500
+RIDE_DISTANCE: int = 40000
+RUN_DISTANCE: int = 10000
+
+TRIATHLON_DISTANCES = {
+    ActivityType.Swim: SWIM_DISTANCE,
+    ActivityType.Ride: RIDE_DISTANCE,
+    ActivityType.Run: RUN_DISTANCE,
+}
+
+
+class Activity(Protocol):
+    distance: float | None
+    type: ActivityType | None
+
+
+class TriathlonMixin(Activity):
+    def triathlon_percentage(self, precision: int = 2) -> float:
+        try:
+            return round(((self.distance or 0) / TRIATHLON_DISTANCES[self.type]) * 100, precision)
+        except KeyError:
+            return 0

--- a/strava/models.py
+++ b/strava/models.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ValidationError
 
 from strava.data_models import DetailedActivity, SummaryActivity, SummaryAthlete
 from strava.exceptions import StravaError, StravaNotAuthenticatedError, StravaNotFoundError, StravaPaidFeatureError
-from strava.mixins import TriathlonMixin
+from strava.mixins import CleanEmptyLatLngMixin, TriathlonMixin
 from weather.models import Weather
 
 logger = logging.getLogger(__name__)
@@ -26,11 +26,11 @@ Point = tuple[float, float]
 T = TypeVar("T", bound=BaseModel)
 
 
-class SummaryActivityTriathlon(TriathlonMixin, SummaryActivity):
+class SummaryActivityTriathlon(CleanEmptyLatLngMixin, TriathlonMixin, SummaryActivity):
     pass
 
 
-class DetailedActivityTriathlon(TriathlonMixin, DetailedActivity):
+class DetailedActivityTriathlon(CleanEmptyLatLngMixin, TriathlonMixin, DetailedActivity):
     pass
 
 
@@ -179,6 +179,7 @@ class Runner(models.Model):
             try:
                 yield SummaryActivityTriathlon.model_validate(activity)
             except ValidationError:
+                logger.exception("Model %s failed to validate with data %s", SummaryActivityTriathlon, activity)
                 pass
 
     def activity(self, activity_id: int) -> DetailedActivityTriathlon:

--- a/strava/models.py
+++ b/strava/models.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ValidationError
 
 from strava.data_models import DetailedActivity, SummaryActivity, SummaryAthlete
 from strava.exceptions import StravaError, StravaNotAuthenticatedError, StravaNotFoundError, StravaPaidFeatureError
+from strava.mixins import TriathlonMixin
 from weather.models import Weather
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,14 @@ logger = logging.getLogger(__name__)
 Point = tuple[float, float]
 
 T = TypeVar("T", bound=BaseModel)
+
+
+class SummaryActivityTriathlon(TriathlonMixin, SummaryActivity):
+    pass
+
+
+class DetailedActivityTriathlon(TriathlonMixin, DetailedActivity):
+    pass
 
 
 class Runner(models.Model):
@@ -165,16 +174,16 @@ class Runner(models.Model):
         except ValidationError:
             raise Http404("Strava athlete not found or invalid data")
 
-    def get_activities(self) -> Iterable[SummaryActivity]:
+    def get_activities(self) -> Iterable[SummaryActivityTriathlon]:
         for activity in self.make_call("athlete/activities"):
             try:
-                yield SummaryActivity.model_validate(activity)
+                yield SummaryActivityTriathlon.model_validate(activity)
             except ValidationError:
                 pass
 
-    def activity(self, activity_id: int) -> DetailedActivity:
+    def activity(self, activity_id: int) -> DetailedActivityTriathlon:
         try:
-            return DetailedActivity.model_validate(self.make_call(f"activities/{activity_id}"))
+            return DetailedActivityTriathlon.model_validate(self.make_call(f"activities/{activity_id}"))
         except ValidationError as e:
             raise Http404("Strava activity not found or invalid data") from e
 

--- a/strava/templates/strava/activities.html
+++ b/strava/templates/strava/activities.html
@@ -17,6 +17,7 @@
                 <th>Distance</th>
                 <th>Moving Time</th>
                 <th>Total Time</th>
+                <th>Triathlon %</th>
                 <th></th>
             </tr>
         </thead>
@@ -28,6 +29,7 @@
                     <td>{{ activity.distance|metric:"m"|nbsp }}</td>
                     <td>{{ activity.moving_time|precisedelta|shorten_time|nbsp }}</td>
                     <td>{{ activity.elapsed_time|precisedelta|shorten_time|nbsp }}</td>
+                    <td>{{ activity.triathlon_percentage|default:0 }}%</td>
                     <td><a class="btn btn-primary" href="{% url 'strava:activity' activity.id %}">Details</a></td>
                 </tr>
             {% empty %}

--- a/strava/templates/strava/activity.html
+++ b/strava/templates/strava/activity.html
@@ -1,9 +1,18 @@
 {% extends "base.html" %}
 
+{% load abbreviations humanize markup %}
+
 {% block title %}{{ run.name }}{% endblock %}
 
 {% block content %}
   <h2>Run</h2>
   <h1>{{ activity.name }}</h1>
+  <div>
+    <p>Distance: {{ activity.distance|metric:"m"|nbsp }}</p>
+    <p>Moving Time: {{ activity.moving_time|precisedelta|shorten_time|nbsp }}</p>
+    <p>Total Time: {{ activity.elapsed_time|precisedelta|shorten_time|nbsp }}</p>
+    <p>Triathlon %: {{ activity.triathlon_percentage|default:0 }}%</p>
+  </div>
   <img src="{% url 'strava:activity_svg' activity.id %}" class="mx-auto max-w-full" />
+  <p>{{ activity.description|default:"No description available." }}</p>
 {% endblock content %}

--- a/strava/tests/models/test_runner.py
+++ b/strava/tests/models/test_runner.py
@@ -9,14 +9,14 @@ import pytest
 from model_bakery import baker
 from pydantic import ValidationError
 
-from strava.data_models import DetailedActivity, SummaryActivity, SummaryAthlete
+from strava.data_models import DetailedActivity, SummaryAthlete
 from strava.exceptions import (
     StravaError,
     StravaNotAuthenticatedError,
     StravaNotFoundError,
     StravaPaidFeatureError,
 )
-from strava.models import Runner
+from strava.models import DetailedActivityTriathlon, Runner, SummaryActivityTriathlon
 
 
 @pytest.mark.django_db
@@ -247,7 +247,7 @@ def test_get_activities(mock_strava_request):
     mock_strava_request.return_value.status_code = HTTPStatus.OK
     runner: Runner = baker.make(Runner, access_expires="9999999999")
     activities = runner.get_activities()
-    assert list(activities) == [SummaryActivity.model_validate(item) for item in data]
+    assert list(activities) == [SummaryActivityTriathlon.model_validate(item) for item in data]
 
 
 @pytest.mark.django_db
@@ -268,7 +268,7 @@ def test_activity(mock_strava_request):
     mock_strava_request.return_value.status_code = HTTPStatus.OK
     runner: Runner = baker.make(Runner, access_expires="9999999999")
     activity = runner.activity(1)
-    assert activity == DetailedActivity.model_validate(data)
+    assert activity == DetailedActivityTriathlon.model_validate(data)
 
 
 @pytest.mark.django_db

--- a/strava/tests/test_clean_empty_mixin.py
+++ b/strava/tests/test_clean_empty_mixin.py
@@ -1,0 +1,37 @@
+from strava.mixins import CleanEmptyLatLngMixin
+
+
+def test_clean_empty_latlng_mixin_empty():
+    data = {
+        "start_latlng": [],
+        "end_latlng": [],
+    }
+
+    data = CleanEmptyLatLngMixin.clean_empty_latlng(data)  # ty: ignore[call-non-callable]
+
+    assert data["start_latlng"] is None
+    assert data["end_latlng"] is None
+
+
+def test_clean_empty_latlng_mixin_none():
+    data = {
+        "start_latlng": None,
+        "end_latlng": None,
+    }
+
+    data = CleanEmptyLatLngMixin.clean_empty_latlng(data)  # ty: ignore[call-non-callable]
+
+    assert data["start_latlng"] is None
+    assert data["end_latlng"] is None
+
+
+def test_clean_empty_latlng_mixin():
+    data = {
+        "start_latlng": [1, 2],
+        "end_latlng": [1, 2],
+    }
+
+    data = CleanEmptyLatLngMixin.clean_empty_latlng(data)  # ty: ignore[call-non-callable]
+
+    assert data["start_latlng"] == [1, 2]
+    assert data["end_latlng"] == [1, 2]

--- a/strava/tests/test_triathlon.py
+++ b/strava/tests/test_triathlon.py
@@ -1,0 +1,49 @@
+from strava.data_models import ActivityType
+from strava.mixins.triathlon import RIDE_DISTANCE, RUN_DISTANCE, SWIM_DISTANCE, TriathlonMixin
+
+FIFTY_PERCENT = 50
+THIRTY_THREE_PERCENT = 33.33
+
+
+class DummyActivity(TriathlonMixin):
+    def __init__(self, distance, type_):
+        self.distance = distance
+        self.type = type_
+
+
+def test_triathlon_percentage_swim():
+    activity = DummyActivity(SWIM_DISTANCE // 2, ActivityType.Swim)
+    assert activity.triathlon_percentage() == FIFTY_PERCENT
+
+
+def test_triathlon_percentage_bike():
+    activity = DummyActivity(RIDE_DISTANCE // 2, ActivityType.Ride)
+    assert activity.triathlon_percentage() == FIFTY_PERCENT
+
+
+def test_triathlon_percentage_run():
+    activity = DummyActivity(RUN_DISTANCE // 2, ActivityType.Run)
+    assert activity.triathlon_percentage() == FIFTY_PERCENT
+
+
+def test_triathlon_percentage_run_third():
+    activity = DummyActivity(RUN_DISTANCE // 3, ActivityType.Run)
+    assert activity.triathlon_percentage() == THIRTY_THREE_PERCENT
+
+
+def test_triathlon_percentage_none_distance():
+    activity = DummyActivity(None, ActivityType.Run)
+    assert activity.triathlon_percentage() == 0
+
+
+def test_triathlon_percentage_none_type():
+    activity = DummyActivity(1000, None)
+    assert activity.triathlon_percentage() == 0
+
+
+def test_triathlon_percentage_invalid_type():
+    class FakeType:
+        pass
+
+    activity = DummyActivity(1000, FakeType())
+    assert activity.triathlon_percentage() == 0

--- a/tach.toml
+++ b/tach.toml
@@ -13,3 +13,11 @@ source_roots = [
 [[modules ]]
 path = "runtimeexceptions"
 depends_on = []
+
+[[modules ]]
+path = "weather"
+depends_on = []
+
+[[modules ]]
+path = "strava"
+depends_on = ["weather"]


### PR DESCRIPTION
- **feat(tests): add TriathlonDistanceMixin and corresponding tests for percentage calculations**


- **feat(triathlon): integrate TriathlonMixin into activity models and templates for percentage calculations**


- **feat(mixins): add CleanEmptyLatLngMixin for cleaning empty latitude/longitude fields**


- **feat(pre-commit): add local ty check hook for type checking**


- **feat(tach.toml): add module dependencies for weather and strava**


- **fix(models): update activity methods to use UpdatableActivity and integrate Triathlon models in tests**

## Summary by Sourcery

Integrate triathlon-specific calculations and data cleaning into the Strava activity pipeline, update models and templates to surface the new metrics, enhance activity update handling, and bolster type checking and module dependency management.

New Features:
- Add TriathlonMixin to compute swim, bike, and run completion percentage and integrate it into activity data models
- Introduce CleanEmptyLatLngMixin to sanitize empty latitude/longitude fields in Pydantic models
- Display triathlon percentage alongside distance and time metrics in activity list and detail templates

Enhancements:
- Refactor Runner.get_activities and activity retrieval to use Triathlon-enabled Pydantic models
- Switch update_activity to use UpdatableActivity for name and description updates

Build:
- Declare module dependencies for weather and strava in tach.toml

CI:
- Add local 'ty' pre-commit hook for type checking

Tests:
- Add unit tests for TriathlonMixin and CleanEmptyLatLngMixin
- Update existing runner model tests to use SummaryActivityTriathlon and DetailedActivityTriathlon