### PR TITLE
triathlon

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "debugpy",
+            "request": "launch",
+            "name": "Django: runserver",
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "runserver"
+            ],
+            "django": true
+        }
+    ]
+}

--- a/strava/models.py
+++ b/strava/models.py
@@ -195,7 +195,7 @@ class Runner(models.Model):
         """
 
         result = self.make_call(f"activities/{activity_id}", data.model_dump(), method="PUT")
-        return DetailedActivity.model_validate(result)
+        return DetailedActivityTriathlon.model_validate(result)
 
     @staticmethod
     def get_distance(point1: Point, point2: Point) -> float:

--- a/strava/models.py
+++ b/strava/models.py
@@ -137,7 +137,7 @@ class Runner(models.Model):
     def _make_call(
         cls,
         path: str,
-        args: dict[str, Any] = {},
+        data: dict[str, Any] = {},
         method: str = "GET",
         authentication: str | None = None,
     ) -> dict[str, Any]:
@@ -153,21 +153,21 @@ class Runner(models.Model):
         if authentication is not None:
             headers["Authorization"] = f"Bearer {authentication}"
 
-        data = requests.request(method, url, headers=headers, data=args)
+        response = requests.request(method, url, headers=headers, data=data)
 
-        if data.status_code == HTTPStatus.OK:
-            return data.json()
+        if response.status_code == HTTPStatus.OK:
+            return response.json()
 
-        if data.status_code == HTTPStatus.UNAUTHORIZED:
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
             raise StravaNotAuthenticatedError()
 
-        if data.status_code == HTTPStatus.PAYMENT_REQUIRED:
+        if response.status_code == HTTPStatus.PAYMENT_REQUIRED:
             raise StravaPaidFeatureError()
 
-        if data.status_code == HTTPStatus.NOT_FOUND:
+        if response.status_code == HTTPStatus.NOT_FOUND:
             raise StravaNotFoundError(url)
 
-        raise StravaError(f"Got {data.status_code} from strava")
+        raise StravaError(f"Got {response.status_code} from strava, {response.text}")
 
     def get_details(self) -> SummaryAthlete:
         try:

--- a/strava/models.py
+++ b/strava/models.py
@@ -137,7 +137,7 @@ class Runner(models.Model):
     def _make_call(
         cls,
         path: str,
-        data: dict[str, Any] = {},
+        data: dict[str, Any] | None = None,
         method: str = "GET",
         authentication: str | None = None,
     ) -> dict[str, Any]:
@@ -153,7 +153,7 @@ class Runner(models.Model):
         if authentication is not None:
             headers["Authorization"] = f"Bearer {authentication}"
 
-        response = requests.request(method, url, headers=headers, data=data)
+        response = requests.request(method, url, headers=headers, data=data or {}, timeout=30)
 
         if response.status_code == HTTPStatus.OK:
             return response.json()

--- a/strava/tests/models/test_runner.py
+++ b/strava/tests/models/test_runner.py
@@ -191,6 +191,7 @@ def test__make_call_authorized(mock_strava_request):
             "Authorization": "Bearer token",
         },
         data={},
+        timeout=30,
     )
 
 


### PR DESCRIPTION
- **fix(models): rename 'args' to 'data' in _make_call method and update response handling for clarity**


- **fix(models): update update_activity method to validate result using DetailedActivityTriathlon**


- **feat(vscode): add launch configuration for Django runserver**

## Summary by Sourcery

Improve API request handling and model validation in strava models, and add VSCode launch configuration for Django runserver

New Features:
- Add VSCode launch configuration to run the Django development server

Bug Fixes:
- Rename `_make_call` parameter from `args` to `data` and correct usages of the response object
- Enhance `_make_call` error reporting to include response text
- Switch `update_activity` to validate responses with `DetailedActivityTriathlon` instead of `DetailedActivity`