### PR TITLE
prefrences

### DIFF
--- a/strava/commands/find_or_create_activity.py
+++ b/strava/commands/find_or_create_activity.py
@@ -31,13 +31,13 @@ class FindOrCreateActivity:
 
             weather: Weather | None = None
 
-            tz = getattr(activity_data.start_date, "tzinfo", None)
+            tz = getattr(activity_data.end_date, "tzinfo", None)
             now = datetime.datetime.now(tz=tz)
 
             if (
                 activity_data.end_latlng
-                and activity_data.start_date
-                and abs((now - activity_data.start_date).total_seconds()) <= self.RECENT_ACTIVITY_THRESHOLD_SECONDS
+                and activity_data.end_date
+                and abs((now - activity_data.end_date).total_seconds()) <= self.RECENT_ACTIVITY_THRESHOLD_SECONDS
             ):
                 logger.debug(f"activity_data: {activity_data=}")
                 lat: float = activity_data.end_latlng.root[0]

--- a/strava/fields.py
+++ b/strava/fields.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.models.expressions import BaseExpression
+
+
+class EnumListField(models.JSONField):
+    """
+    A custom field that serializes a list of items from a specified enum.
+    """
+
+    def __init__(self, enum_type: type[Enum], *args, **kwargs):
+        if not issubclass(enum_type, Enum):
+            raise TypeError("enum_type must be a subclass of enum.Enum")
+        self.enum_type = enum_type
+        super().__init__(*args, **kwargs)
+
+    def to_python(self, value: list[str] | None) -> list[str]:
+        value = super().to_python(value)
+        if value is None:
+            return []
+
+        if not isinstance(value, list):
+            raise ValidationError("Value must be a list.")
+
+        valid_choices = [member.value for member in self.enum_type]
+        for item in value:
+            if not isinstance(item, str) or item not in valid_choices:
+                raise ValidationError(f"Invalid choice '{item}'. Must be one of {valid_choices}.")
+
+        return value
+
+    def from_db_value(
+        self, value: str | None, expression: BaseExpression, connection: BaseDatabaseWrapper
+    ) -> list[str]:
+        if value is None:
+            return []
+        return super().from_db_value(value, expression, connection)
+
+    def get_prep_value(self, value: list[str] | None):
+        return super().get_prep_value(self.to_python(value))

--- a/strava/mixins/__init__.py
+++ b/strava/mixins/__init__.py
@@ -1,4 +1,5 @@
 from strava.mixins.cleaning import CleanEmptyLatLngMixin
+from strava.mixins.time import TimeMixin
 from strava.mixins.triathlon import TriathlonMixin
 
-__all__ = ["CleanEmptyLatLngMixin", "TriathlonMixin"]
+__all__ = ["CleanEmptyLatLngMixin", "TimeMixin", "TriathlonMixin"]

--- a/strava/mixins/time.py
+++ b/strava/mixins/time.py
@@ -8,6 +8,6 @@ class TimeMixin:
 
     @property
     def end_date(self) -> datetime | None:
-        if self.start_date and self.moving_time:
-            return self.start_date + timedelta(seconds=self.moving_time)
+        if self.start_date and self.elapsed_time:
+            return self.start_date + timedelta(seconds=self.elapsed_time)
         return None

--- a/strava/mixins/time.py
+++ b/strava/mixins/time.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timedelta
+
+
+class TimeMixin:
+    """
+    Mixin to add end_date functionality to an activity.
+    """
+
+    @property
+    def end_date(self) -> datetime | None:
+        if self.start_date and self.moving_time:
+            return self.start_date + timedelta(seconds=self.moving_time)
+        return None

--- a/strava/models.py
+++ b/strava/models.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ValidationError
 
 from strava.data_models import DetailedActivity, SummaryActivity, SummaryAthlete, UpdatableActivity
 from strava.exceptions import StravaError, StravaNotAuthenticatedError, StravaNotFoundError, StravaPaidFeatureError
-from strava.mixins import CleanEmptyLatLngMixin, TriathlonMixin
+from strava.mixins import CleanEmptyLatLngMixin, TimeMixin, TriathlonMixin
 from strava.utils import MarkedString
 from weather.models import Weather
 
@@ -27,11 +27,11 @@ Point = tuple[float, float]
 T = TypeVar("T", bound=BaseModel)
 
 
-class SummaryActivityTriathlon(CleanEmptyLatLngMixin, TriathlonMixin, SummaryActivity):
+class SummaryActivityTriathlon(CleanEmptyLatLngMixin, TriathlonMixin, TimeMixin, SummaryActivity):
     pass
 
 
-class DetailedActivityTriathlon(CleanEmptyLatLngMixin, TriathlonMixin, DetailedActivity):
+class DetailedActivityTriathlon(CleanEmptyLatLngMixin, TriathlonMixin, TimeMixin, DetailedActivity):
     pass
 
 

--- a/strava/tests/commands/test_find_or_create_activity.py
+++ b/strava/tests/commands/test_find_or_create_activity.py
@@ -29,6 +29,7 @@ def activity_data():
         name="Morning Run",
         description="",
         start_date=datetime.datetime.now(tz=datetime.UTC),
+        elapsed_time=1,
     )
 
 
@@ -57,7 +58,12 @@ def test_time_checking(mock_activity, mock_weather, monkeypatch, delta, assertio
     now = datetime.datetime.now(tz=datetime.UTC)
     start_date = now - delta
 
-    mock_activity.return_value = DetailedActivityTriathlon(id=123, start_date=start_date, end_latlng=LatLng([1.0, 2.0]))
+    mock_activity.return_value = DetailedActivityTriathlon(
+        id=123,
+        start_date=start_date,
+        end_latlng=LatLng([1.0, 2.0]),
+        elapsed_time=1,
+    )
     mock_weather.return_value = baker.make(Weather)
 
     runner = baker.make(Runner)

--- a/strava/tests/commands/test_find_or_create_activity.py
+++ b/strava/tests/commands/test_find_or_create_activity.py
@@ -6,8 +6,13 @@ from model_bakery import baker
 
 from strava.commands.find_or_create_activity import FindOrCreateActivity
 from strava.data_models import ActivityType, DetailedActivity, LatLng
+from strava.mixins import TimeMixin
 from strava.models import Activity, DetailedActivityTriathlon, Runner
 from weather.models import Weather
+
+
+class DetailedActivityTime(DetailedActivity, TimeMixin):
+    pass
 
 
 @pytest.fixture
@@ -17,7 +22,7 @@ def runner():
 
 @pytest.fixture
 def activity_data():
-    return DetailedActivity(
+    return DetailedActivityTime(
         id=12345,
         type=ActivityType.Run,
         end_latlng=LatLng([51.5, -0.1]),

--- a/strava/tests/test_enum_field.py
+++ b/strava/tests/test_enum_field.py
@@ -1,0 +1,71 @@
+from enum import Enum
+
+from django.core.exceptions import ValidationError
+
+import pytest
+
+from strava.fields import EnumListField
+
+
+class ActivityType(Enum):
+    WALK = "walk"
+    RUN = "run"
+    SWIM = "swim"
+    BIKE = "bike"
+
+
+@pytest.fixture
+def enum_list_field():
+    return EnumListField(enum_type=ActivityType)
+
+
+def test_to_python_method_on_valid_list(enum_list_field):
+    """Tests that to_python handles a valid list correctly."""
+    valid_list = [ActivityType.WALK.value, ActivityType.RUN.value]
+    result = enum_list_field.to_python(valid_list)
+    assert result == valid_list
+
+
+def test_to_python_method_on_invalid_list(enum_list_field):
+    """Tests that to_python raises a ValidationError for an invalid list."""
+    invalid_list = [ActivityType.BIKE.value, "hike"]
+    with pytest.raises(ValidationError, match="Invalid choice 'hike'"):
+        enum_list_field.to_python(invalid_list)
+
+
+def test_to_python_method_on_none(enum_list_field):
+    """Tests that to_python returns an empty list for None."""
+    result = enum_list_field.to_python(None)
+    assert result == []
+
+
+def test_to_python_method_on_non_list_input(enum_list_field):
+    """Tests that to_python raises an error for non-list input."""
+    with pytest.raises(ValidationError, match="Value must be a list."):
+        enum_list_field.to_python("a_string")
+
+
+def test_get_prep_value_method(enum_list_field):
+    """Tests that get_prep_value serializes a list to a JSON string."""
+    valid_list = [ActivityType.WALK.value, ActivityType.SWIM.value]
+    result = enum_list_field.get_prep_value(valid_list)
+    assert result == ["walk", "swim"]
+
+
+def test_from_db_value_method(enum_list_field):
+    """Tests that from_db_value deserializes a JSON string back to a list."""
+    json_string = '["run", "bike"]'
+    result = enum_list_field.from_db_value(json_string, None, None)
+    assert result == [ActivityType.RUN.value, ActivityType.BIKE.value]
+
+
+def test_from_db_value_method_on_none(enum_list_field):
+    """Tests that from_db_value returns an empty list for None."""
+    result = enum_list_field.from_db_value(None, None, None)
+    assert result == []
+
+
+def test_invalid_enum_type_on_init():
+    """Tests that the field raises an error if initialized with a non-enum type."""
+    with pytest.raises(TypeError, match="enum_type must be a subclass of enum.Enum"):
+        EnumListField(enum_type=str)  # ty: ignore[invalid-argument-type] this is what I'm testings


### PR DESCRIPTION
- **feat: add EnumListField for serializing enum lists with validation**


- **feat: add TimeMixin for end_date functionality and update models to use it**


- **fix: correct time handling by using end_date instead of start_date**

## Summary by Sourcery

Introduce a custom EnumListField for list-of-enum JSONField support and a TimeMixin for computing end_date, apply the mixin to triathlon models, and fix activity recency logic to use the new end_date property.

New Features:
- Add EnumListField to serialize and validate lists of enum values
- Add TimeMixin to calculate end_date for activities and apply it to triathlon models

Bug Fixes:
- Use end_date instead of start_date for recent activity threshold and timezone handling in activity creation

Tests:
- Add unit tests for EnumListField validation and serialization