### PR TITLE
bug dupe weather

### DIFF
--- a/strava/models.py
+++ b/strava/models.py
@@ -244,8 +244,8 @@ class Activity(models.Model):
 
         data = UpdatableActivity.model_validate(
             {
-                "description": "\n\n".join(s for s in [description, weather] if s != ""),
-                "name": f"{name} {emoji}",
+                "description": description,
+                "name": name,
             }
         )
 

--- a/strava/tasks/create_event.py
+++ b/strava/tasks/create_event.py
@@ -22,13 +22,13 @@ def create_event(**kwargs: Any) -> int:
 
     logger.info("Event created: %d", event.pk)
 
-    update_activity_weather.enqueue(event.pk)
-    logger.info("Weather update enqueued for event: %d", event.pk)
+    update_comparison.enqueue(event.owner.pk, event.object_id)
+    logger.info("Comparison update enqueued for runner: %d, activity: %d", event.owner.pk, event.object_id)
 
     update_triathlon_score.enqueue(event.owner.pk, event.object_id)
     logger.info("Triathlon score update enqueued for runner: %d, activity: %d", event.owner.pk, event.object_id)
 
-    update_comparison.enqueue(event.owner.pk, event.object_id)
-    logger.info("Comparison update enqueued for runner: %d, activity: %d", event.owner.pk, event.object_id)
+    update_activity_weather.enqueue(event.pk)
+    logger.info("Weather update enqueued for event: %d", event.pk)
 
     return event.pk


### PR DESCRIPTION
- **fix: dupliacte weater in description and name**


- **fix: reorder task**

## Summary by Sourcery

Fix duplicate weather/emoji concatenation in activity metadata and adjust the order of enqueued comparison and weather update tasks when creating an event.

Bug Fixes:
- Remove duplicate weather data and emoji from activity description and name in add_weather

Enhancements:
- Reorder enqueuing of comparison and weather update tasks in create_event