### PR TITLE
fix: skip update when triathlon score is zero

### DIFF
--- a/strava/commands/update_triathlon_score.py
+++ b/strava/commands/update_triathlon_score.py
@@ -24,6 +24,8 @@ class UpdateTriathlonScore:
         logger.debug("Activity data: %s", activity)
 
         score: float = activity.triathlon_percentage() / 100
+        if score == 0:
+            return
         score_string = MarkedString(f"tri%: {score:.2f}.", self.MARKER_STRING)
         logger.debug("Score string: %s", score_string)
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Skip updating the triathlon score when the calculated score is zero.